### PR TITLE
Bugfix/ssfr 107 incorrect download summary button

### DIFF
--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -67,7 +67,7 @@ const Board = () => {
   const isFinalizedForSummary = boardStatus === possibleBoardStatuses.finalized && isAdmin;
   const isBoard = (isBoardVisible && !isFormSubmit && !isLoading);
   const isNoBoard = (!isLoading && !isBoardVisible || isFormSubmit);
-  const layoutHeight = (isBoard && isAdmin) ? '84vh' : '92vh';
+  const layoutHeight = (isBoard || (isAdmin && isBoard)) ? '84vh' : '92vh';
   const isPageWithBoard = location.pathname.startsWith('/board/');
   const isShowTimer = isTimerVisible && isPageWithBoard;
 

--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -67,7 +67,7 @@ const Board = () => {
   const isFinalizedForSummary = boardStatus === possibleBoardStatuses.finalized && isAdmin;
   const isBoard = (isBoardVisible && !isFormSubmit && !isLoading);
   const isNoBoard = (!isLoading && !isBoardVisible || isFormSubmit);
-  const layoutHeight = isBoard ? '84vh' : '92vh';
+  const layoutHeight = (isBoard && isAdmin) ? '84vh' : '92vh';
   const isPageWithBoard = location.pathname.startsWith('/board/');
   const isShowTimer = isTimerVisible && isPageWithBoard;
 

--- a/src/components/BoardManagement/BoardsManagement.module.scss
+++ b/src/components/BoardManagement/BoardsManagement.module.scss
@@ -9,7 +9,6 @@
   @include flexbox(column, flex-start, unset, nowrap);
   width: 100%;
   height: 70vh;
-  margin: 0 32px;
 }
 
 .boardsManagementContainer {
@@ -18,6 +17,7 @@
   width: 100%;
   height: 75vh;
   margin-top: 20px;
+  padding: 0 32px;
   overflow-y: scroll;
   scrollbar-width: thin;
   scrollbar-color: transparent transparent;

--- a/src/components/BoardSummary/BoardSummaryColumnDefs.ts
+++ b/src/components/BoardSummary/BoardSummaryColumnDefs.ts
@@ -15,7 +15,7 @@ export const boardSummaryDefsList = [{
   }, {
     headerName: 'COMMENT',
     field: 'cardComment',
-    filter:'agTextColumnFilter',
+    filter: 'agTextColumnFilter',
     floatingFilter: true,
     flex: 2
   }, {

--- a/src/components/BoardSummary/BoardSummaryColumnDefs.ts
+++ b/src/components/BoardSummary/BoardSummaryColumnDefs.ts
@@ -11,19 +11,11 @@ export const boardSummaryDefsList = [{
     field: 'columnId',
     filter: 'agTextColumnFilter',
     maxWidth: 170,
-    filterParams: {
-      caseSensitive: true,
-      defaultOption: 'startsWith'
-    },
     floatingFilter: true
   }, {
     headerName: 'COMMENT',
-    field: 'cardComment', filter:
-    'agTextColumnFilter',
-    filterParams: {
-      caseSensitive: true,
-      defaultOption: 'startsWith'
-    },
+    field: 'cardComment',
+    filter:'agTextColumnFilter',
     floatingFilter: true,
     flex: 2
   }, {
@@ -31,10 +23,7 @@ export const boardSummaryDefsList = [{
     field: 'cardTags',
     filter: 'agTextColumnFilter',
     maxWidth: 216,
-    filterParams: {
-      caseSensitive: true,
-      defaultOption: 'startsWith'
-    }, floatingFilter: true
+    floatingFilter: true
   }, {
     headerName: 'REACTIONS',
     field: 'cardReactions',
@@ -45,10 +34,6 @@ export const boardSummaryDefsList = [{
     headerName: 'AUTHOR',
     field: 'cardAuthor',
     filter: 'agTextColumnFilter',
-    filterParams: {
-      caseSensitive: true,
-      defaultOption: 'startsWith'
-    },
     floatingFilter: true,
     flex: 1
 }];

--- a/src/components/BoardSummary/DownloadCSVButton.tsx
+++ b/src/components/BoardSummary/DownloadCSVButton.tsx
@@ -1,21 +1,25 @@
 import { IDownloadBoardSummaryCSVButton } from '../../interfaces/dowloadBoardSummaryCSVButton';
-import { IconButton } from '@mui/joy';
+import { Button, IconButton } from '@mui/joy';
 import { icons } from '../../theme/icons/icons';
 
 export const DownloadBoardSummaryCSVButton = (props: IDownloadBoardSummaryCSVButton) => {
   const { isDisabled, onClick } = props;
-  const iconSize = 36;
+  const iconSize = 16;
+  const fontSize = '16px';
 
   return (
-    <IconButton
+    <Button
       color='neutral'
       onClick={onClick}
-      size='md'
-      variant='plain'
+      size='sm'
+      variant='outlined'
       disabled={isDisabled}
-    >
-      {icons.download('#303439', iconSize)}
-    </IconButton>
+      startDecorator={icons.download('#303439', iconSize)}
+      sx={{
+        fontSize
+      }}
+    >Download CSV Report
+    </Button>
   );
 };
 

--- a/src/components/CardAvatar/CardAvatar.tsx
+++ b/src/components/CardAvatar/CardAvatar.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { Avatar } from '@mui/joy';
+import { Avatar, Tooltip } from '@mui/joy';
 import { ICardAvatar } from '../../interfaces/cardAvatar';
 import { defaultTheme } from '../../theme/default';
 import { getInitials } from '../../utils/userInitials';
@@ -16,46 +16,52 @@ const CardAvatar = (props: ICardAvatar) => {
 
     if (isIncognito) {
       return (
-        <Avatar
-          data-testid='incognito-avatar'
-          onClick={onToggle}
-          sx={{
-            cursor: 'pointer',
-            boxShadow: customBoxShadow,
-            '&.MuiAvatar-variantSoft': { backgroundColor: defaultTheme.color1 } }}
-        >
-          {icons.incognito}
-        </Avatar>
-        );
-      }
-      if (isInitials) {
-        return (
+        <Tooltip title={cardAuthor}>
           <Avatar
-            data-testid='initials-avatar'
+            data-testid='incognito-avatar'
             onClick={onToggle}
             sx={{
               cursor: 'pointer',
               boxShadow: customBoxShadow,
-              color: 'var(--friendly-palette-shades-50)',
-              '&.MuiAvatar-variantSoft': { backgroundColor: defaultTheme.color1 }
-            }}
+              '&.MuiAvatar-variantSoft': { backgroundColor: defaultTheme.color1 } }}
           >
-            {getInitials(cardAuthor)}
+            {icons.incognito}
           </Avatar>
+        </Tooltip>
+        );
+      }
+      if (isInitials) {
+        return (
+          <Tooltip title={cardAuthor}>
+            <Avatar
+              data-testid='initials-avatar'
+              onClick={onToggle}
+              sx={{
+                cursor: 'pointer',
+                boxShadow: customBoxShadow,
+                color: 'var(--friendly-palette-shades-50)',
+                '&.MuiAvatar-variantSoft': { backgroundColor: defaultTheme.color1 }
+              }}
+            >
+              {getInitials(cardAuthor)}
+            </Avatar>
+          </Tooltip>
         );
       }
       if (isAvatar) {
         return (
-          <Avatar
-            data-testid='card-avatar'
-            onClick={onToggle}
-            alt={cardAuthorAvatar}
-            src={cardAuthorAvatar}
-            sx={{
-              cursor: 'pointer',
-              boxShadow: customBoxShadow
-            }}
-        ></Avatar>
+          <Tooltip title={cardAuthor}>
+            <Avatar
+              data-testid='card-avatar'
+              onClick={onToggle}
+              alt={cardAuthorAvatar}
+              src={cardAuthorAvatar}
+              sx={{
+                cursor: 'pointer',
+                boxShadow: customBoxShadow
+              }}
+            ></Avatar>
+          </Tooltip>
       );
     }
 

--- a/src/components/Column/Column.module.scss
+++ b/src/components/Column/Column.module.scss
@@ -34,12 +34,14 @@
   }
 
   &__header__subtitle {
+    display: block;
+    max-height: 55px;
     color: $friendly-palette-neutral-500;
     margin-bottom: 0;
     padding: 0 8px;
     text-align: center;
     font-weight: 300;
-    font-size: 18px;
+    font-size: 16px;
     line-height: 27.24px;
     font-family: "Open Sans", sans-serif;
     cursor: context-menu;

--- a/src/components/Column/Column.module.scss
+++ b/src/components/Column/Column.module.scss
@@ -79,7 +79,7 @@
     &__max {
       @include flexbox(column, unset, unset, nowrap);
       width: 100%;
-      height: calc(100% - 48px);
+      height: calc(100% - 90px);
       padding-top: 25px;
       overflow-y: scroll;
       scrollbar-width: thin;

--- a/src/components/Column/Column.tsx
+++ b/src/components/Column/Column.tsx
@@ -10,7 +10,7 @@ import { IColumnCard } from '../../interfaces/columnCard';
 import { cardAPI } from '../../api/CardAPI';
 import { localStorageManager } from '../../utils/localStorageManager';
 import { possibleBoardStatuses } from '../../constants';
-import { sortByDateStartOld } from '../../utils/sortByDate';
+import { sortByDateStartNew } from '../../utils/sortByDate';
 
 import EditCard from '../EditCard/EditCard';
 import FinalizedCard from '../FinalizedCard/FinalizedCard';
@@ -36,7 +36,7 @@ const Column = (props: IColumn) => {
   const { createCard, updateCard } = cardAPI();
 
   const { boardId, boardStatus, isAddingDisabled } = useContext(BoardContext);
-  const [finalizedCards, setFinalizedCards] = useState(() => sortByDateStartOld(columnCards));
+  const [finalizedCards, setFinalizedCards] = useState(() => sortByDateStartNew(columnCards));
   const [editableCard, setEditableCard] = useState<IColumnCard>(initialCard);
   const [isButtonDisabled, setIsButtonDisabled] = useState(false);
   const isActiveBoard = boardStatus === 'active';
@@ -44,7 +44,7 @@ const Column = (props: IColumn) => {
 
   useEffect(() => {
     if (columnCards) {
-      setFinalizedCards(sortByDateStartOld(columnCards));
+      setFinalizedCards(sortByDateStartNew(columnCards));
     }
   }, [columnCards]);
 
@@ -61,7 +61,7 @@ const Column = (props: IColumn) => {
     } else {
       createCard(boardId, columnId, handledCard)
         .then((res) => {
-          setFinalizedCards((prevCards) => [...prevCards, { ...handledCard, _id: res.data._id }]);
+          setFinalizedCards((prevCards) => [{ ...handledCard, _id: res.data._id }, ...prevCards ]);
         });
     }
   };
@@ -156,7 +156,7 @@ const Column = (props: IColumn) => {
       .then((res) => {
         const updatedCard = { ...newCard, _id: res.data._id };
 
-        setFinalizedCards((prevCards) => [...prevCards, updatedCard]);
+        setFinalizedCards((prevCards) => [updatedCard, ...prevCards]);
       });
   };
 

--- a/src/components/InteractivePanel/InteractivePanel.module.scss
+++ b/src/components/InteractivePanel/InteractivePanel.module.scss
@@ -18,6 +18,13 @@
   width: 33%;
 }
 
+.panelLeftLabel,
+.panelRightLabel {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
 .interactivePanelElementLeft {
   justify-content: flex-start;
 
@@ -31,5 +38,7 @@
 
   .panelRightLabel {
     margin-right: 24px;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 }

--- a/src/components/InteractivePanel/InteractivePanel.tsx
+++ b/src/components/InteractivePanel/InteractivePanel.tsx
@@ -1,8 +1,10 @@
+import { IconButton, Tooltip } from '@mui/joy';
 import { ReactNode, useEffect, useState } from 'react';
-import { IconButton } from '@mui/joy';
 import { PropsChildren } from '../../interfaces/interactivePanelChildren';
+import { SUMMARY_LABEL_TAIL } from '../../constants';
 import { icons } from '../../theme/icons/icons';
 import { isString } from 'lodash';
+import { truncateInteractivePanelLabel } from '../../utils/truncateInteractivePanelLabel';
 import { useNavigate } from 'react-router';
 
 import classes from './InteractivePanel.module.scss';
@@ -10,6 +12,7 @@ import classes from './InteractivePanel.module.scss';
 const InteractivePanel = (props: { childrenConfig: PropsChildren[] }) => {
   const navigate = useNavigate();
   const { childrenConfig } = props;
+  const { truncateSummaryLabel } = truncateInteractivePanelLabel();
   const [contentLeft, setContentLeft] = useState<ReactNode | string>(null);
   const [contentCenter, setContentCenter] = useState<ReactNode | string>(null);
   const [contentRigth, setContentRigtht] = useState<ReactNode | string>(null);
@@ -17,6 +20,7 @@ const InteractivePanel = (props: { childrenConfig: PropsChildren[] }) => {
   const [forwardLabel, setForwardLabel] = useState<string>('');
   const isBackward = isString(contentLeft);
   const isFarward = isString(contentRigth);
+  const isSummaryPage = backwardLabel.indexOf(SUMMARY_LABEL_TAIL) > 0;
 
   const onBackward = () => {
     if (isBackward) {
@@ -77,9 +81,12 @@ const InteractivePanel = (props: { childrenConfig: PropsChildren[] }) => {
             </span> : contentLeft
           }
         </span>
-        <span className={classes.panelLeftLabel}>
-          {backwardLabel}
-        </span>
+        {isSummaryPage ?
+          (<Tooltip title={backwardLabel}>
+            <span className={classes.panelLeftLabel}>{truncateSummaryLabel(backwardLabel)}</span>
+          </Tooltip>) :
+          <span className={classes.panelLeftLabel}>{backwardLabel}</span>
+        }
       </div>
       <div className={classes.interactivePanelElementCenter}>
         {contentCenter}

--- a/src/components/InteractivePanel/InteractivePanel.tsx
+++ b/src/components/InteractivePanel/InteractivePanel.tsx
@@ -82,7 +82,10 @@ const InteractivePanel = (props: { childrenConfig: PropsChildren[] }) => {
           }
         </span>
         {isSummaryPage ?
-          (<Tooltip title={backwardLabel}>
+          (<Tooltip
+            title={backwardLabel}
+            disableHoverListener={backwardLabel.length < (17 + SUMMARY_LABEL_TAIL.length)}
+          >
             <span className={classes.panelLeftLabel}>{truncateSummaryLabel(backwardLabel)}</span>
           </Tooltip>) :
           <span className={classes.panelLeftLabel}>{backwardLabel}</span>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -62,3 +62,4 @@ export const DOWNLOAD_CSV_REPORT = 'Download CSV Report';
 export const NO_BOARDS_MESSAGE = 'No boards found';
 export const SELECT_ALL = 'Select all';
 export const THERE_ARE_NO_BOARDS_MESSAGE = 'There are no boards';
+export const SUMMARY_LABEL_TAIL = '| Summary';

--- a/src/utils/truncateInteractivePanelLabel.ts
+++ b/src/utils/truncateInteractivePanelLabel.ts
@@ -1,0 +1,15 @@
+import { SUMMARY_LABEL_TAIL } from '../constants';
+
+export const truncateInteractivePanelLabel = () => {
+  const truncateSummaryLabel = (inputString: string) => {
+    const tailIndex = inputString.indexOf(SUMMARY_LABEL_TAIL);
+      const textBeforeSummary = inputString.substring(0, tailIndex);
+
+      return textBeforeSummary.length > 17 ? `${textBeforeSummary.substring(0, 17)}... ${SUMMARY_LABEL_TAIL}` :
+        textBeforeSummary;
+  };
+
+  return {
+    truncateSummaryLabel
+  };
+};

--- a/src/utils/truncateInteractivePanelLabel.ts
+++ b/src/utils/truncateInteractivePanelLabel.ts
@@ -6,7 +6,7 @@ export const truncateInteractivePanelLabel = () => {
       const textBeforeSummary = inputString.substring(0, tailIndex);
 
       return textBeforeSummary.length > 17 ? `${textBeforeSummary.substring(0, 17)}... ${SUMMARY_LABEL_TAIL}` :
-        textBeforeSummary;
+        `${textBeforeSummary} ${SUMMARY_LABEL_TAIL}`;
   };
 
   return {


### PR DESCRIPTION
- Changed icon button component to button component with label and icon slot on download summary page
- Fixed board height conditions for different board statuses and user roles
- Added utility to handle backward label for board summary page
- Removed filter params for grid in board summary page
- Added tooltip for avatars
- Changed sorting settings for column cards
- Changed margin to padding for board management container element in an attempt to reproduce the desired design on the prod